### PR TITLE
Update SURF contact link in 05-02-europe.astro

### DIFF
--- a/src/components/01-index-page/05-02-europe.astro
+++ b/src/components/01-index-page/05-02-europe.astro
@@ -6,11 +6,11 @@ const listItems = [
     text: "SURF (Netherlands) is the RAiD Registration Agency for Europe.",
   },
   {
-    text: `Individual researchers or research organisations should contact SURF directly to discuss service acquisition.`,
+    text: `Individual researchers or research organisations should review SURF's RAiD webpage and complete an Expression of Interest form.`,
     links: [
       {
-        url: "mailto:clifford.tatum@surf.nl?subject=RAiD%20(EU%20-%20SURF)%20inquiry&body=Hello%2C%0A%0AI%20am%20located%20in%20Europe%20and%20am%20interested%20in%20using%20RAiD.%0A%0A%5BProvide%20your%20organisation's%20name%20and%20any%20additional%20information%20here%5D",
-        text: "contact SURF directly",
+        url: "https://www.surf.nl/en/themes/open-science/raid",
+        text: "SURF's RAiD webpage",
       },
     ],
   },


### PR DESCRIPTION
Clifford's email address replaced with a link to the SURF RAiD webpage, which contains an EOI form for their RAiD service.