### PR TITLE
Created News and Events page to list the news and events via post concept

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1894,6 +1894,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.6.1.tgz",
       "integrity": "sha512-aQ2TV7wIf+q2Oi6gGWMINHWEAZqoP0eH6/mihodfTJYATPWyd03JIGVfjtYUJlkNdNSKxDXwEe/r/Zx4CZ1FPg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.11.0",
         "@astrojs/internal-helpers": "0.6.1",
@@ -2111,6 +2112,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -3344,6 +3346,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4629,6 +4632,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -4758,6 +4762,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5143,6 +5148,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.39.0.tgz",
       "integrity": "sha512-thI8kNc02yNvnmJp8dr3fNWJ9tCONDhp6TV35X6HkKGGs9E6q7YWCHbe5vKiTa7TAiNcFEmXKj3X/pG2b3ci0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.7"
       },
@@ -5497,6 +5503,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -5732,6 +5739,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6084,6 +6092,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
       "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "postcss": "^8.5.3",
@@ -6776,6 +6785,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/04-news-events-page/01-news-events-intro.astro
+++ b/src/components/04-news-events-page/01-news-events-intro.astro
@@ -1,0 +1,16 @@
+---
+import backgroundLaptop from "@/images/backgrounds/background-laptop.webp";
+---
+
+<div
+  class="bg-cover bg-center"
+  style=`background-image: url(${backgroundLaptop.src});`
+>
+  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-[380px]">
+    <div class="grid grid-cols-1 h-full">
+      <h1 class="text-white font-light text-3xl self-end pb-20">
+        News & Events
+      </h1>
+    </div>
+  </div>
+</div>

--- a/src/components/04-news-events-page/02-news-grid.astro
+++ b/src/components/04-news-events-page/02-news-grid.astro
@@ -1,0 +1,48 @@
+---
+const allPosts = await Astro.glob("./posts/*.astro");
+
+const newsPosts = allPosts
+  .filter((p) => p.metadata?.type === "news")
+  .sort((a, b) => new Date(b.metadata.date) - new Date(a.metadata.date));
+---
+
+{
+  newsPosts.length > 0 && (
+    <div class="bg-raidGray">
+      <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-14">
+        <h2 class="text-raidPrimary font-semibold text-2xl mb-8">
+          Latest News
+        </h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {newsPosts.map((post) => {
+            const Post = post.default;
+            const { title, date } = post.metadata;
+            const slug = post.file.split("/").pop().replace(".astro", "");
+            return (
+              <div class="bg-white p-6 rounded shadow flex flex-col gap-3">
+                <p class="text-xs text-raidTextPrimary font-semibold uppercase tracking-wide">
+                  {new Date(date).toLocaleDateString("en-AU", {
+                    year: "numeric",
+                    month: "long",
+                  })}
+                </p>
+                <h3 class="text-base font-semibold text-raidTextPrimaryDark leading-snug">
+                  {title}
+                </h3>
+                <div class="text-sm text-gray-600 flex-grow">
+                  <Post />
+                </div>
+                <a
+                  href={`https://raid.org/news-events/${slug}`}
+                  class="text-sm text-raidTextPrimaryDark hover:underline font-semibold mt-auto"
+                >
+                  Read more &rarr;
+                </a>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/04-news-events-page/03-events-list.astro
+++ b/src/components/04-news-events-page/03-events-list.astro
@@ -1,0 +1,111 @@
+---
+const allPosts = await Astro.glob("./posts/*.astro");
+
+const today = new Date();
+today.setHours(0, 0, 0, 0);
+
+const eventPosts = allPosts
+  .filter((p) => p.metadata?.type === "event")
+  .sort((a, b) => new Date(a.metadata.date) - new Date(b.metadata.date));
+
+const upcoming = eventPosts.filter((p) => new Date(p.metadata.date) >= today);
+const past = eventPosts
+  .filter((p) => new Date(p.metadata.date) < today)
+  .reverse();
+---
+
+{
+  eventPosts.length > 0 && (
+    <div class="bg-white">
+      <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-14">
+        {upcoming.length > 0 && (
+          <>
+            <h2 class="text-raidPrimary font-semibold text-2xl mb-8">
+              Upcoming Events
+            </h2>
+            <div class="flex flex-col gap-8 mb-16">
+              {upcoming.map((post) => {
+                const Post = post.default;
+                const { title, date, location } = post.metadata;
+                const slug = post.file.split("/").pop().replace(".astro", "");
+                return (
+                  <div class="border-l-4 border-raidPrimary pl-6 py-2">
+                    <p class="text-sm text-raidTextPrimary font-semibold">
+                      {new Date(date).toLocaleDateString("en-AU", {
+                        year: "numeric",
+                        month: "long",
+                        day: "numeric",
+                      })}
+                      {location && (
+                        <>
+                          <span class="mx-2 text-raidSecondary">·</span>
+                          {location}
+                        </>
+                      )}
+                    </p>
+                    <h3 class="text-lg font-semibold text-raidTextPrimaryDark mt-1">
+                      {title}
+                    </h3>
+                    <div class="text-sm text-gray-600 mt-2 max-w-2xl">
+                      <Post />
+                    </div>
+                    <a
+                      href={`https://raid.org/news-events/${slug}`}
+                      class="inline-block mt-3 text-sm text-raidTextPrimaryDark hover:underline font-semibold"
+                    >
+                      Learn more &rarr;
+                    </a>
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        )}
+
+        {past.length > 0 && (
+          <>
+            <h2 class="text-raidPrimary font-semibold text-2xl mb-8">
+              Past Events
+            </h2>
+            <div class="flex flex-col gap-8">
+              {past.map((post) => {
+                const Post = post.default;
+                const { title, date, location } = post.metadata;
+                const slug = post.file.split("/").pop().replace(".astro", "");
+                return (
+                  <div class="border-l-4 border-raidGray pl-6 py-2">
+                    <p class="text-sm text-raidTextPrimary font-semibold">
+                      {new Date(date).toLocaleDateString("en-AU", {
+                        year: "numeric",
+                        month: "long",
+                        day: "numeric",
+                      })}
+                      {location && (
+                        <>
+                          <span class="mx-2 text-raidSecondary">·</span>
+                          {location}
+                        </>
+                      )}
+                    </p>
+                    <h3 class="text-lg font-semibold text-raidTextPrimaryDark mt-1">
+                      {title}
+                    </h3>
+                    <div class="text-sm text-gray-600 mt-2 max-w-2xl">
+                      <Post />
+                    </div>
+                    <a
+                      href={`https://raid.org/news-events/${slug}`}
+                      class="inline-block mt-3 text-sm text-raidTextPrimaryDark hover:underline font-semibold"
+                    >
+                      View details &rarr;
+                    </a>
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/04-news-events-page/posts/2024-02-ardc-datacite.astro
+++ b/src/components/04-news-events-page/posts/2024-02-ardc-datacite.astro
@@ -1,0 +1,11 @@
+---
+export const metadata = {
+  title: "ARDC and DataCite Announce Partnership to Deliver the RAiD Service",
+  date: "2024-02-01",
+  type: "news",
+};
+---
+
+<p>
+  The ARDC and DataCite have joined forces to deliver RAiD, a fast and reliable service for identifying and tracking research projects and activities.
+</p>

--- a/src/components/04-news-events-page/posts/2025-10-eResearchAustralasia.astro
+++ b/src/components/04-news-events-page/posts/2025-10-eResearchAustralasia.astro
@@ -1,0 +1,13 @@
+---
+export const metadata = {
+  title: "2025 eResearch Australasia Conference",
+  date: "2025-10-20",
+  type: "event",
+  location: "Online",
+};
+---
+
+<p>
+ Join the 2025 eResearch Australasia Conference in Brisbane/Meanjin to exchange 
+ ideas and exemplars concerning new information-centric research capabilities.
+</p>

--- a/src/components/04-news-events-page/posts/2026-03-RAiD-US.astro
+++ b/src/components/04-news-events-page/posts/2026-03-RAiD-US.astro
@@ -1,0 +1,11 @@
+---
+export const metadata = {
+  title: "RAiD Expansion to US Strengthens Global Research Transparency and Tracking",
+  date: "2026-03-17",
+  type: "news",
+};
+---
+
+<p>
+  The San Diego Supercomputer Center (SDSC) has received a National Science Foundation (NSF) grant to set up an inaugural Research Activity Identifier (RAiD) Registration Agency for the US in partnership...
+</p>

--- a/src/components/04-news-events-page/posts/2026-06-open-science-conference.astro
+++ b/src/components/04-news-events-page/posts/2026-06-open-science-conference.astro
@@ -1,0 +1,13 @@
+---
+export const metadata = {
+  title: "Open Science Conference 2026",
+  date: "2026-06-03",
+  type: "event",
+  location: "Melbourne, Australia",
+};
+---
+
+<p>
+ Join us in this third and final session – focused on persistent identifiers – of a 3-part series 
+ to explore the NHMRC/MRFF Open Science Policy and its impact on the...
+</p>

--- a/src/components/04-news-events-page/posts/HOW-TO-CREATE-A-POST.md
+++ b/src/components/04-news-events-page/posts/HOW-TO-CREATE-A-POST.md
@@ -1,0 +1,100 @@
+# How to Create a News or Event Post
+
+## 1. Create a new file in this folder
+
+Name the file using the format: `YYYY-MM-short-description.astro`
+
+Examples:
+- `2026-05-new-partnership.astro`
+- `2026-06-annual-conference.astro`
+
+The filename becomes the URL slug, e.g. `/news-events/2026-05-new-partnership`
+
+---
+
+## 2. Copy this template into your file
+
+```astro
+---
+export const metadata = {
+  title: "Your Post Title",
+  date: "2026-05-01",
+  type: "news",
+};
+---
+
+<p>Write your content here.</p>
+```
+
+---
+
+## 3. Fill in the metadata
+
+| Field      | Required | Description                                      |
+|------------|----------|--------------------------------------------------|
+| `title`    | Yes      | The title shown on the listing and post page     |
+| `date`     | Yes      | Publication date in `YYYY-MM-DD` format          |
+| `type`     | Yes      | Either `"news"` or `"event"`                     |
+| `location` | No       | For events only — e.g. `"Online"` or `"Sydney"`  |
+
+### News post example
+
+```astro
+---
+export const metadata = {
+  title: "RAiD Reaches 1000 Registered Institutions",
+  date: "2026-05-10",
+  type: "news",
+};
+---
+
+<p>We are thrilled to announce that RAiD has reached a major milestone...</p>
+```
+
+### Event post example
+
+```astro
+---
+export const metadata = {
+  title: "RAiD Workshop at eResearch Australasia",
+  date: "2026-10-20",
+  type: "event",
+  location: "Adelaide, Australia",
+};
+---
+
+<p>Join us at eResearch Australasia for a hands-on RAiD workshop.</p>
+<p>Registration opens in August. More details to follow.</p>
+```
+
+---
+
+## 4. Write your content
+
+Everything below the `---` closing fence is your post body. Use standard HTML tags:
+
+```html
+<p>A paragraph of text.</p>
+
+<p>Another paragraph.</p>
+
+<ul>
+  <li>A bullet point</li>
+  <li>Another bullet point</li>
+</ul>
+
+<a href="https://example.com">A link</a>
+```
+
+---
+
+## 5. Save and done
+
+The post will automatically appear:
+- On the listing page (`/news-events/`)
+- At its own URL (`/news-events/your-filename`)
+
+Events are sorted by date and split into **Upcoming** and **Past** automatically.
+News posts are sorted newest first.
+
+No other files need to be changed.

--- a/src/components/layout-components/navbar.astro
+++ b/src/components/layout-components/navbar.astro
@@ -18,6 +18,10 @@ const links = [
     text: "Contact",
   },
   {
+    href: `https://raid.org/news-events/`,
+    text: "News & Events",
+  },
+  {
     href: `${searchPageUrl}`,
     text: "Search",
   },

--- a/src/pages/news-events/[slug].astro
+++ b/src/pages/news-events/[slug].astro
@@ -1,0 +1,61 @@
+---
+import Layout from "@/layouts/main.astro";
+
+export async function getStaticPaths() {
+  const posts = await Astro.glob(
+    "../../components/04-news-events-page/posts/*.astro"
+  );
+  return posts.map((post) => {
+    const slug = post.file.split("/").pop().replace(".astro", "");
+    return {
+      params: { slug },
+      props: { post },
+    };
+  });
+}
+
+const { post } = Astro.props;
+const { title, date, type, location } = post.metadata;
+const Post = post.default;
+
+const formattedDate = new Date(date).toLocaleDateString("en-AU", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
+---
+
+<Layout title={`${title} | RAiD`}>
+  <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-14">
+    <a
+      href="https://raid.org/news-events"
+      class="text-sm text-raidTextPrimary hover:underline"
+    >
+      &larr; Back to News &amp; Events
+    </a>
+
+    <div class="mt-8">
+      <p class="text-xs text-raidTextPrimary font-semibold uppercase tracking-wide">
+        {type === "event" ? "Event" : "News"}
+        {
+          location && (
+            <>
+              <span class="mx-2">·</span>
+              {location}
+            </>
+          )
+        }
+      </p>
+      <h1 class="text-raidTextPrimaryDark font-semibold text-2xl mt-2">
+        {title}
+      </h1>
+      <p class="text-sm text-gray-500 mt-1">{formattedDate}</p>
+    </div>
+
+    <hr class="my-8 border-raidGray" />
+
+    <div class="text-gray-700 leading-relaxed">
+      <Post />
+    </div>
+  </div>
+</Layout>

--- a/src/pages/news-events/index.astro
+++ b/src/pages/news-events/index.astro
@@ -1,0 +1,12 @@
+---
+import Layout from "@/layouts/main.astro";
+import NewsEventsIntro from "@/components/04-news-events-page/01-news-events-intro.astro";
+import NewsGrid from "@/components/04-news-events-page/02-news-grid.astro";
+import EventsList from "@/components/04-news-events-page/03-events-list.astro";
+---
+
+<Layout title="News & Events | RAiD">
+  <NewsEventsIntro />
+  <NewsGrid />
+  <EventsList />
+</Layout>


### PR DESCRIPTION
Jira: https://ardc.atlassian.net/browse/RAID-582

Change log:

- Created a new News & Events page at /news-events/
- Added News & Events link to the site navbar
- Each post is a standalone .astro component in src/components/04-news-events-page/posts/
- Posts are auto-discovered — no other files need to be edited to publish a new post
- News posts are displayed in a card grid, sorted newest first
- Event posts are automatically split into Upcoming and Past sections based on date
- Each post has its own dedicated URL (e.g. /news-events/2026-05-my-post)
- Added 4 example posts (2 news, 2 events) to demonstrate the structure
- Added a HOW-TO-CREATE-A-POST.md guide in the posts folder for content authors